### PR TITLE
Fix superfluous space

### DIFF
--- a/cranberry_brownies.md
+++ b/cranberry_brownies.md
@@ -2,7 +2,7 @@
 
 *Kuchen, vegan*
 
-** 1/2 Blech**
+**1/2 Blech**
 
 ---
 


### PR DESCRIPTION
With the space present the yield line is not interpreted as bold, making the recipe invalid